### PR TITLE
Adds recent MPAS publications

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -28,6 +28,30 @@
 				<td width="743">&nbsp;</td>
 			</tr>
 			<tr>
+				<td><strong>2017</strong></td>
+			</tr>
+			<tr>
+                                <td>
+                                    Ringler, T. D., Saenz, J.A., Wolfram, P.J., and Van Roekel, L., 2017: A Thickness-Weighted Average Perspective of Force Balance in an Idealized Circumpolar Current 
+                                    J. Phys. Oceanogr., 47(2), 285-302. doi:10.1175/JPO-D-16-0096.1
+                                    (<a href="http://journals.ametsoc.org/doi/abs/10.1175/JPO-D-16-0096.1" target="_blank">pdf</a>)
+                                </td>
+			</tr>
+			<tr>
+			        <td>&nbsp;</td>
+                        </tr>
+			<tr>
+			<tr>
+                                <td>
+                                    Wolfram, P. J. and Ringler, T. D., 2017: Quantifying Residual, Eddy, and Mean Flow Effects on Mixing in an Idealized Circumpolar Current 
+                                    J. Phys. Oceanogr., 47(8), 1897-1920. doi:10.1175/JPO-D-16-0101.1
+                                    (<a href="http://journals.ametsoc.org/doi/abs/10.1175/JPO-D-16-0101.1" target="_blank">pdf</a>)
+                                </td>
+			</tr>
+			<tr>
+			        <td>&nbsp;</td>
+                        </tr>
+			<tr>
 				<td><strong>2016</strong></td>
 			</tr>
 			<tr>
@@ -106,6 +130,17 @@
                                     Hagos, S., L. R. Leung, Q. Yang, C. Zhao, and J. Lu, 2015: Resolution and Dynamical Core Dependence 
                                     of Atmospheric River Frequency in Global Model Simulations. J. Climate, 28, 2764-2776. doi:10.1175/JCLI-D-14-00567.1
                                     (<a href="http://journals.ametsoc.org/doi/full/10.1175/JCLI-D-14-00567.1" target="_blank">pdf</a>)
+                                </td>
+			</tr>
+			<tr>
+			        <td>&nbsp;</td>
+                        </tr>
+			<tr>
+                                <td>
+                                    Wolfram, P. J., Ringler, T. D., Maltrud, M. E., Jacobsen, D. W., Petersen, M. R., 2015: Diagnosing isopycnal diffusivity 
+                                    in an eddying, idealized midlatitude ocean basin via Lagrangian, in Situ, Global, High-Performance Particle Tracking (LIGHT). 
+                                    J. Phys. Oceanogr., 45(8), 2114-2133. doi:10.1175/JPO-D-14-0260.1
+                                    (<a href="http://journals.ametsoc.org/doi/abs/10.1175/JPO-D-14-0260.1" target="_blank">pdf</a>)
                                 </td>
 			</tr>
 			<tr>


### PR DESCRIPTION
Recent papers related to LIGHT and ZISO simulations by LANL MPAS group.

Note, we have another two papers in review that should eventually be added to this list too.