### PR TITLE
Update the reported lines that need to be commented out for parallel static interp for v7.0

### DIFF
--- a/atmosphere/atmosphere_meshes.html
+++ b/atmosphere/atmosphere_meshes.html
@@ -115,7 +115,7 @@ in parallel, one must:
 </p>
 
 <p class="ind2">
-(1) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L199-L204">lines 199 and 204</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
+(1) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L217-L222">lines 117 and 222</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
 </p>
 
 <p class="ind2">
@@ -142,7 +142,7 @@ in parallel, one must:
 </p>
 
 <p class="ind2">
-(1) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L199-L204">lines 199 and 204</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
+(1) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L217-L222">lines 117 and 222</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
 </p>
 
 <p class="ind2">
@@ -239,7 +239,7 @@ in parallel, one must:
 <br>
 </p>
 <p class="ind3">
-(a) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L199-L204">lines 199 and 204</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
+(1) comment-out the code between <a href="https://github.com/MPAS-Dev/MPAS-Model/blob/v5.0/src/core_init_atmosphere/mpas_init_atm_cases.F#L217-L222">lines 117 and 222</a> in src/core_init_atmosphere/mpas_init_atm_cases.F that ordinarily prevents the parallel processing of static fields; and
 </p>
 <p class="ind3">
 (b) ensure that the "cvt" partition file prefix (e.g., x5.6488066.cvt.part.) is specified in the config_block_decomp_file_prefix


### PR DESCRIPTION
This PR updates the lines that are reportedly needed to be commented out to run the static interpolation in parallel.

With 7.0, the lines that atmosphere_meshes.html reported needed to be commented
out are now a few lines lower due to the bdyMaskCell check.